### PR TITLE
issue resolved

### DIFF
--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -47,4 +47,15 @@ async def test_send_markdown_email(email_service):
         'email_verification', 
         **user_data
     )
-    
+
+@pytest.mark.asyncio
+async def test_send_email_with_template_error(email_service):
+    """Test that errors in template rendering are caught."""
+    # Mock render_template to raise an error
+    email_service.template_manager.render_template = MagicMock(side_effect=ValueError("Template error"))
+
+    with pytest.raises(ValueError, match="Error rendering the email template"):
+        await email_service.send_user_email({
+            "email": "test@example.com",
+            "name": "Test User"
+        }, 'email_verification')


### PR DESCRIPTION
Currently, render_template is mocked to return a MagicMock object, which is then passed as the HTML content to the send_email method. This causes the assert_called_once_with assertion to fail when checking the arguments passed to send_email